### PR TITLE
Fix steep learning curve text on educators page

### DIFF
--- a/.claude/claude.md
+++ b/.claude/claude.md
@@ -220,3 +220,17 @@ Speichere deinen Benutzernamen und dein Passwort gut ab!
    ```
 
 **Remember:** Never push broken builds! The build must always succeed.
+
+## Terminology Guide
+
+### Learning Curve (Lernkurve)
+**Important:** A **steep learning curve** means something is EASY to learn (you make rapid progress).
+A **flat/shallow learning curve** means something is HARD to learn (slow progress despite effort).
+
+**In German:**
+- **schwierig/kompliziert = flache Lernkurve** (flat curve = slow progress)
+- **einfach = steile Lernkurve** (steep curve = fast progress)
+
+Most people use this incorrectly! When describing difficulty in this course:
+- Use "flache Lernkurve" for challenging content
+- Add footnote to explain the correct meaning (see info-fuer-eltern.md line 245 for example)

--- a/docs/info-fuer-lehrkraefte.md
+++ b/docs/info-fuer-lehrkraefte.md
@@ -349,7 +349,7 @@ Dieser Kurs verfolgt einen **radikal anderen Ansatz** als die meisten Kinder-Pro
 
 **Unser Ansatz:**
 - Kinder lernen von Anfang an die richtigen Tools
-- Die Lernkurve ist anfangs steiler, aber **alles Gelernte ist sofort wertvoll**
+- Die Lernkurve ist anfangs flacher[^1], aber **alles Gelernte ist sofort wertvoll**
 - Kinder entwickeln echte, übertragbare Fähigkeiten
 - Nach 6-12 Monaten können sie bereits mit professionellen Tools arbeiten
 
@@ -1310,3 +1310,5 @@ Möchtest du einen ähnlichen Kurs aufsetzen? Hast du Fragen oder Anregungen?
 ---
 
 **Viel Erfolg beim Aufsetzen deines eigenen Kurses! Gemeinsam machen wir Programmieren für Kinder zugänglich. 🚀**
+
+[^1]: Eine flache Lernkurve ergibt sich, wenn man trotz hohem Arbeitsaufwand wenig Fortschritt macht, die Komplexität der Aufgabe also hoch ist. Die Steigung der Lernkurve ist also gering und die Kurve sieht "flach" aus. Die wenigsten Leute verstehen das und meistens wird "steile Lernkurve" für schwierig zu lernenden Inhalte verwendet, was logisch keinen Sinn macht.


### PR DESCRIPTION
- Changed "steile Lernkurve" to "flache Lernkurve" in info-fuer-lehrkraefte.md
- Added footnote explaining the correct meaning of "flat learning curve"
- Added terminology guide to .claude/claude.md with "schwer = flache Lernkurve"

The correct usage: flat/shallow learning curve = difficult (slow progress despite effort)